### PR TITLE
Add Option to start Spark History Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,14 @@ COPY conf/sshd_config.template /etc/ssh/sshd_config.template
 
 COPY scripts/dork-submit /usr/bin
 COPY scripts/dork-shell /usr/bin
+COPY scripts/start-history-server /usr/bin
 COPY scripts/start-worker /usr/bin
 COPY scripts/start-master /usr/bin
 COPY scripts/setup-users /usr/bin
 
 RUN chmod u+x /usr/bin/dork-submit
 RUN chmod u+x /usr/bin/dork-shell
+RUN chmod u+x /usr/bin/start-history-server
 RUN chmod u+x /usr/bin/start-worker
 RUN chmod u+x /usr/bin/start-master
 RUN chmod u+x /usr/bin/setup-users

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ sudo docker run --net host \
   -e SPARK_USER_ID=1100 \
   -e SPARK_GROUP_NAME=spark \
   -e SPARK_GROUP_ID=1100 \
+  -e SPARK_EVENT_LOG_DIR=/tmp/spark-events \
   datascienceplatform/dorkd:latest-s2.0.2-h2.7 start-master
 ```
 
@@ -58,8 +59,31 @@ sudo docker run -d --net host \
   -e SPARK_GROUP_ID=1100 \
   -e SPARK_SHUFFLE_SERVICE_ENABLED=true \
   -e SPARK_SHUFFLE_SERVICE_PORT=7337 \
+  -e SPARK_EVENT_LOG_DIR=/tmp/spark-events \
   datascienceplatform/dorkd:latest-s2.0.2-h2.7 start-worker
 ```
+
+### Starting a History Server
+
+```
+sudo docker run -d --net host \
+  -v /etc/localtime:/etc/localtime:ro \
+  -v /etc/timezone:/etc/timezone:ro \
+  -e SPARK_EVENT_LOG_DIR=/tmp/spark-events \
+  -e SPARK_HISTORY_SERVER_PORT=18080 \
+  -e SPARK_HISTORY_SERVER_UPDATE_INTERVAL=10s \
+  -e SPARK_HISTORY_SERVER_MAXDISKUSAGE=10g \
+  -e SPARK_HISTORY_SERVER_MEMORY=1g \
+  -e SPARK_USER_NAME=spark \
+  -e SPARK_USER_ID=1100 \
+  -e SPARK_GROUP_NAME=spark \
+  -e SPARK_GROUP_ID=1100 \
+  datascienceplatform/dorkd:latest-s2.0.2-h2.7 start-history-server
+```
+### Disabling logs after the event
+
+By default, the after-the-event logs for Spark History server are stored under `$SPARK_EVENT_LOG_DIR`. If the variable is not specified, writing of the logs is omitted.
+
 
 ### Submitting an Application
 

--- a/scripts/start-history-server
+++ b/scripts/start-history-server
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "$SPARK_USER_NAME" ] || [ -z "$SPARK_USER_ID" ] || [ -z "$SPARK_GROUP_NAME" ] || [ -z "$SPARK_GROUP_ID" ] || [ -z "$SPARK_EVENT_LOG_DIR" ] || [ -z "$SPARK_HISTORY_SERVER_PORT" ] || [ -z "$SPARK_HISTORY_SERVER_UPDATE_INTERVAL" ] || [ -z "$SPARK_HISTORY_SERVER_MAXDISKUSAGE" ] || [ -z "$SPARK_HISTORY_SERVER_MEMORY" ]
+if [ -z "$SPARK_USER_NAME" ] || [ -z "$SPARK_USER_ID" ] || [ -z "$SPARK_GROUP_NAME" ] || [ -z "$SPARK_GROUP_ID" ] || [ -z "$SPARK_EVENT_LOG_DIR" ] || [ -z "$SPARK_HISTORY_SERVER_PORT" ] || [ -z "$SPARK_HISTORY_SERVER_UPDATE_INTERVAL" ] || [ -z "$SPARK_HISTORY_SERVER_MAX_DISK_USAGE" ]
 then
   echo "Please set all required environment variables."
   exit 1
@@ -22,11 +22,15 @@ fi
 chown -R $SPARK_USER_NAME:$SPARK_GROUP_NAME $SPARK_HOME
 chown -R $SPARK_USER_NAME:$SPARK_GROUP_NAME $SPARK_EVENT_LOG_DIR
 
-export SPARK_DAEMON_MEMORY=$SPARK_HISTORY_SERVER_MEMORY
 export SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=$SPARK_EVENT_LOG_DIR \
 -Dspark.history.fs.update.interval=$SPARK_HISTORY_SERVER_UPDATE_INTERVAL \
 -Dspark.history.ui.port=$SPARK_HISTORY_SERVER_PORT \
--Dspark.history.store.maxDiskUsage=$SPARK_HISTORY_SERVER_MAXDISKUSAGE"
+-Dspark.history.store.maxDiskUsage=$SPARK_HISTORY_SERVER_MAX_DISK_USAGE"
+
+if [ -n "$SPARK_HISTORY_SERVER_CLEANER_MAX_AGE" ]
+then
+   export SPARK_HISTORY_OPTS="-Dspark.history.fs.cleaner.enabled=true -Dspark.history.fs.cleaner.maxAge=$SPARK_HISTORY_SERVER_CLEANER_MAX_AGE "$SPARK_HISTORY_OPTS
+fi
 
 echo "SPARK_HISTORY_OPTS" $SPARK_HISTORY_OPTS
 

--- a/scripts/start-history-server
+++ b/scripts/start-history-server
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "$SPARK_USER_NAME" ] || [ -z "$SPARK_USER_ID" ] || [ -z "$SPARK_GROUP_NAME" ] || [ -z "$SPARK_GROUP_ID" ] || [ -z "$SPARK_EVENT_LOG_DIR" ]
+if [ -z "$SPARK_USER_NAME" ] || [ -z "$SPARK_USER_ID" ] || [ -z "$SPARK_GROUP_NAME" ] || [ -z "$SPARK_GROUP_ID" ] || [ -z "$SPARK_EVENT_LOG_DIR" ] || [ -z "$SPARK_HISTORY_SERVER_PORT" ] || [ -z "$SPARK_HISTORY_SERVER_UPDATE_INTERVAL" ] || [ -z "$SPARK_HISTORY_SERVER_MAXDISKUSAGE" ] || [ -z "$SPARK_HISTORY_SERVER_MEMORY" ]
 then
   echo "Please set all required environment variables."
   exit 1
@@ -22,7 +22,12 @@ fi
 chown -R $SPARK_USER_NAME:$SPARK_GROUP_NAME $SPARK_HOME
 chown -R $SPARK_USER_NAME:$SPARK_GROUP_NAME $SPARK_EVENT_LOG_DIR
 
-export SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=$SPARK_EVENT_LOG_DIR"
+export SPARK_DAEMON_MEMORY=$SPARK_HISTORY_SERVER_MEMORY
+export SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=$SPARK_EVENT_LOG_DIR \
+-Dspark.history.fs.update.interval=$SPARK_HISTORY_SERVER_UPDATE_INTERVAL \
+-Dspark.history.ui.port=$SPARK_HISTORY_SERVER_PORT \
+-Dspark.history.store.maxDiskUsage=$SPARK_HISTORY_SERVER_MAXDISKUSAGE"
+
 echo "SPARK_HISTORY_OPTS" $SPARK_HISTORY_OPTS
 
 . "${SPARK_HOME}/sbin/spark-config.sh"

--- a/scripts/start-history-server
+++ b/scripts/start-history-server
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ -z "$SPARK_USER_NAME" ] || [ -z "$SPARK_USER_ID" ] || [ -z "$SPARK_GROUP_NAME" ] || [ -z "$SPARK_GROUP_ID" ] || [ -z "$SPARK_EVENT_LOG_DIR" ]
+then
+  echo "Please set all required environment variables."
+  exit 1
+fi
+
+setup-users
+
+if [ "$SPARK_EVENT_LOG_DIR" ]
+then
+  if [ -d "$SPARK_EVENT_LOG_DIR" ]
+  then
+    echo "Configuring history server to read from '$SPARK_EVENT_LOG_DIR'"
+  else
+    echo "SPARK_EVENT_LOG_DIR=$SPARK_EVENT_LOG_DIR is defined but is not a directory"
+    exit 1
+  fi
+fi
+
+chown -R $SPARK_USER_NAME:$SPARK_GROUP_NAME $SPARK_HOME
+chown -R $SPARK_USER_NAME:$SPARK_GROUP_NAME $SPARK_EVENT_LOG_DIR
+
+export SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=$SPARK_EVENT_LOG_DIR"
+echo "SPARK_HISTORY_OPTS" $SPARK_HISTORY_OPTS
+
+. "${SPARK_HOME}/sbin/spark-config.sh"
+. "${SPARK_HOME}/bin/load-spark-env.sh"
+
+exec sudo -E -u $SPARK_USER_NAME $SPARK_HOME/bin/spark-class org.apache.spark.deploy.history.HistoryServer "$@"
+

--- a/scripts/start-master
+++ b/scripts/start-master
@@ -36,7 +36,10 @@ then
   if [ -d "$SPARK_EVENT_LOG_DIR" ]
   then
     echo "Configuring master server to write logs to '$SPARK_EVENT_LOG_DIR'"
-    export SPARK_MASTER_OPTS="-Dspark.eventLog.enabled=true -Dspark.eventLog.dir=$SPARK_EVENT_LOG_DIR "$SPARK_MASTER_OPTS
+    export SPARK_DEFAULTS_FILE=$SPARK_HOME/conf/spark-defaults.conf
+    touch $SPARK_DEFAULTS_FILE
+    echo "spark.eventLog.enabled=true" >> $SPARK_DEFAULTS_FILE
+    echo "spark.eventLog.dir=$SPARK_EVENT_LOG_DIR" >> $SPARK_DEFAULTS_FILE
   else
     echo "SPARK_EVENT_LOG_DIR=$SPARK_EVENT_LOG_DIR is defined but is not a directory"
     exit 1

--- a/scripts/start-master
+++ b/scripts/start-master
@@ -16,6 +16,7 @@ export SPARK_MASTER_OPTS="-Dspark.driver.port=$SPARK_PORT_DRIVER \
 -Dspark.executor.port=$SPARK_PORT_EXECUTOR \
 -Dspark.broadcast.factory=org.apache.spark.broadcast.HttpBroadcastFactory"
 
+
 if [ "$SPARK_MASTER_RECOVERY_DIRECTORY" ]
 then
   if [ -d "$SPARK_MASTER_RECOVERY_DIRECTORY" ]
@@ -32,11 +33,34 @@ fi
 echo "SPARK_MASTER_OPTS" $SPARK_MASTER_OPTS
 echo "SPARK_DAEMON_JAVA_OPTS" $SPARK_DAEMON_JAVA_OPTS
 
+
 chown -R $SPARK_USER_NAME $SPARK_HOME
 chgrp -R $SPARK_GROUP_NAME $SPARK_HOME
+
+# Configure and start Spark Hisotry server
+# Edit Spark master options to write event logs to
+if [ "$SPARK_EVENT_LOG_DIR" ]
+then
+  if [ -d "$SPARK_EVENT_LOG_DIR" ]
+  then
+    echo "Configuring master server to write logs to '$SPARK_EVENT_LOG_DIR'"
+    export SPARK_MASTER_OPTS="-Dspark.eventLog.enabled=true -Dspark.eventLog.dir=$SPARK_EVENT_LOG_DIR "$SPARK_MASTER_OPTS
+    export SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=$SPARK_EVENT_LOG_DIR"
+
+    chown -R $SPARK_USER_NAME:$SPARK_GROUP_NAME $SPARK_EVENT_LOG_DIR
+    exec sudo -E -u $SPARK_USER_NAME $SPARK_HOME/sbin/start-history-server.sh "$@" &
+    echo "Hisotry Server started with config'$SPARK_HISTORY_OPTS'"
+  else
+    echo "SPARK_EVENT_LOG_DIR=$SPARK_EVENT_LOG_DIR is defined but is not a directory"
+    exit 1
+  fi
+fi
+echo "SPARK_HISTORY_OPTS" $SPARK_HISTORY_OPTS
+
 
 exec sudo -E -u $SPARK_USER_NAME $SPARK_HOME/bin/spark-class org.apache.spark.deploy.master.Master \
     --ip $SPARK_MASTER_IP \
     --port $SPARK_MASTER_PORT \
     --webui-port $SPARK_MASTER_WEBUI_PORT \
     "$@"
+

--- a/scripts/start-master
+++ b/scripts/start-master
@@ -30,33 +30,24 @@ then
   fi
 fi
 
-echo "SPARK_MASTER_OPTS" $SPARK_MASTER_OPTS
-echo "SPARK_DAEMON_JAVA_OPTS" $SPARK_DAEMON_JAVA_OPTS
-
-
-chown -R $SPARK_USER_NAME $SPARK_HOME
-chgrp -R $SPARK_GROUP_NAME $SPARK_HOME
-
-# Configure and start Spark Hisotry server
-# Edit Spark master options to write event logs to
+# Edit Spark master options to write event logs
 if [ "$SPARK_EVENT_LOG_DIR" ]
 then
   if [ -d "$SPARK_EVENT_LOG_DIR" ]
   then
     echo "Configuring master server to write logs to '$SPARK_EVENT_LOG_DIR'"
     export SPARK_MASTER_OPTS="-Dspark.eventLog.enabled=true -Dspark.eventLog.dir=$SPARK_EVENT_LOG_DIR "$SPARK_MASTER_OPTS
-    export SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=$SPARK_EVENT_LOG_DIR"
-
-    chown -R $SPARK_USER_NAME:$SPARK_GROUP_NAME $SPARK_EVENT_LOG_DIR
-    exec sudo -E -u $SPARK_USER_NAME $SPARK_HOME/sbin/start-history-server.sh "$@" &
-    echo "Hisotry Server started with config'$SPARK_HISTORY_OPTS'"
   else
     echo "SPARK_EVENT_LOG_DIR=$SPARK_EVENT_LOG_DIR is defined but is not a directory"
     exit 1
   fi
 fi
-echo "SPARK_HISTORY_OPTS" $SPARK_HISTORY_OPTS
 
+echo "SPARK_MASTER_OPTS" $SPARK_MASTER_OPTS
+echo "SPARK_DAEMON_JAVA_OPTS" $SPARK_DAEMON_JAVA_OPTS
+
+chown -R $SPARK_USER_NAME $SPARK_HOME
+chgrp -R $SPARK_GROUP_NAME $SPARK_HOME
 
 exec sudo -E -u $SPARK_USER_NAME $SPARK_HOME/bin/spark-class org.apache.spark.deploy.master.Master \
     --ip $SPARK_MASTER_IP \

--- a/scripts/start-worker
+++ b/scripts/start-worker
@@ -23,8 +23,11 @@ if [ "$SPARK_EVENT_LOG_DIR" ]
 then
   if [ -d "$SPARK_EVENT_LOG_DIR" ]
   then
-    echo "Configuring worker  to write logs to '$SPARK_EVENT_LOG_DIR'"
-    export SPARK_WORKER_OPTS="-Dspark.eventLog.enabled=true -Dspark.eventLog.dir=$SPARK_EVENT_LOG_DIR "$SPARK_WORKER_OPTS
+    echo "Configuring worker to write logs to '$SPARK_EVENT_LOG_DIR'"
+    export SPARK_DEFAULTS_FILE=$SPARK_HOME/conf/spark-defaults.conf
+    touch $SPARK_DEFAULTS_FILE
+    echo "spark.eventLog.enabled=true" >> $SPARK_DEFAULTS_FILE
+    echo "spark.eventLog.dir=$SPARK_EVENT_LOG_DIR" >> $SPARK_DEFAULTS_FILE
   else
     echo "SPARK_EVENT_LOG_DIR=$SPARK_EVENT_LOG_DIR is defined but is not a directory"
     exit 1

--- a/scripts/start-worker
+++ b/scripts/start-worker
@@ -18,6 +18,20 @@ export SPARK_WORKER_OPTS="-Dspark.driver.port=$SPARK_PORT_DRIVER \
 -Dspark.shuffle.service.enabled=$SPARK_SHUFFLE_SERVICE_ENABLED \
 -Dspark.shuffle.service.port=$SPARK_SHUFFLE_SERVICE_PORT"
 
+
+if [ "$SPARK_EVENT_LOG_DIR" ]
+then
+  if [ -d "$SPARK_EVENT_LOG_DIR" ]
+  then
+    echo "Configuring worker  to write logs to '$SPARK_EVENT_LOG_DIR'"
+    export SPARK_WORKER_OPTS="-Dspark.eventLog.enabled=true -Dspark.eventLog.dir=$SPARK_EVENT_LOG_DIR "$SPARK_WORKER_OPTS
+  else
+    echo "SPARK_EVENT_LOG_DIR=$SPARK_EVENT_LOG_DIR is defined but is not a directory"
+    exit 1
+  fi
+fi
+
+
 echo "SPARK_WORKER_OPTS: $SPARK_WORKER_OPTS"
 
 chown -R $SPARK_USER_NAME $SPARK_HOME


### PR DESCRIPTION
This PR adds option to write after-the-event logs for both master and workers, which can be picked up by Spark History server. This also adds option to start said server as a separate container