### PR TITLE
fix spark-shell control characters for DSP-5694

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN \
   apt-get update && \
   apt-get install -y software-properties-common && \
   add-apt-repository ppa:openjdk-r/ppa && \
+  add-apt-repository ppa:lokkju/java-compat && \
   apt-get update && \
   apt-get install -y \
     openjdk-8-jdk-headless \
@@ -25,6 +26,7 @@ RUN \
     fortune \
     libxrender1 \
     libnss-ldap ldap-utils \
+    libjline2-java \
     openssh-server && \
   apt-get clean all
 


### PR DESCRIPTION
https://stackoverflow.com/questions/50567410/scala-repl-no-echo-on-input I have tested this solution with ubuntu-18 on VC, it works for me, we could try to use it in docker image to see if it's working